### PR TITLE
修改 空指针和语法修改

### DIFF
--- a/src/we-validator.js
+++ b/src/we-validator.js
@@ -148,7 +148,7 @@ class WeValidator {
       let messages = this.options.messages
       let defaultMessage = WeValidator.RULES[ruleName].message
 
-      if(messages.hasOwnProperty(attr) && messages[attr][ruleName]){
+      if(messages && messages.hasOwnProperty(attr) && messages[attr][ruleName]){
         defaultMessage = messages[attr][ruleName]
       }
 
@@ -252,7 +252,9 @@ class WeValidator {
                   }
                   
                   if(!multiCheck){
-                    errorParam && this._showErrorMessage(errorParam, onMessage)
+                    if (errorParam) {
+                      this._showErrorMessage(errorParam, onMessage);
+                    }
                     return false
                   }
                 }


### PR DESCRIPTION
### 1. 空指针

当仅希望使用默认错误消息时，messages 不设置，如下：

```javascript
new WeValidator({
       rules: {
          [data._name]: {
            required: data._required,
          },
        },
        // messages: {
        //   [data._name]: {
        //     required: '请输入xxx',
        //   },
        // },
}
```

这个时候，直接使用 `messages.hasOwnProperty`，将会空指针报错。

### 2. 语法修改

`errorParam && this._showErrorMessage(errorParam, onMessage);`，这个写法挺奇怪的，很好奇这是 JS 那个版本的语法。