### PR TITLE
required: false 不进行“必须”验证

### DIFF
--- a/src/we-validator.js
+++ b/src/we-validator.js
@@ -69,7 +69,7 @@ class WeValidator {
       }
 
       if(isFunction(rule)){
-        if(ruleName === 'required'){
+        if(ruleName === 'required' && param){
           return requiredFn(value)
         }else{
           if(skip){


### PR DESCRIPTION
当这样使用：

```javascript
new WeValidator({
  rules: {
    [data._name]: {
      required: data._required,
    },
  },
});
 ```
 
` required: false` 时，不应该进行 check。